### PR TITLE
Lukasz timestamping improvements

### DIFF
--- a/src/main/java/com/sumologic/jenkins/jenkinssumologicplugin/PluginDescriptorImpl.java
+++ b/src/main/java/com/sumologic/jenkins/jenkinssumologicplugin/PluginDescriptorImpl.java
@@ -34,7 +34,7 @@ public final class PluginDescriptorImpl extends BuildStepDescriptor<Publisher> {
   private String sourceCategoryJobStatus = "jenkinsJobStatus";
   private String sourceCategoryBuildLogs = "jenkinsBuildLogs";
 
-  private boolean timestampingEnabled = true;
+  private boolean timestampingEnabled = false;
   private boolean buildLogEnabled = true;
 
   public PluginDescriptorImpl() {

--- a/src/main/java/com/sumologic/jenkins/jenkinssumologicplugin/PluginDescriptorImpl.java
+++ b/src/main/java/com/sumologic/jenkins/jenkinssumologicplugin/PluginDescriptorImpl.java
@@ -34,7 +34,6 @@ public final class PluginDescriptorImpl extends BuildStepDescriptor<Publisher> {
   private String sourceCategoryJobStatus = "jenkinsJobStatus";
   private String sourceCategoryBuildLogs = "jenkinsBuildLogs";
 
-  private boolean timestampingEnabled = false;
   private boolean buildLogEnabled = true;
 
   public PluginDescriptorImpl() {
@@ -62,7 +61,6 @@ public final class PluginDescriptorImpl extends BuildStepDescriptor<Publisher> {
     collectorUrl = formData.getString("url");
     queryPortal = formData.getString("queryPortal");
     maxLines = formData.getString("maxLines");
-    timestampingEnabled = formData.getBoolean("timestampingEnabled");
     buildLogEnabled = formData.getBoolean("buildLogEnabled");
 
     sourceNamePeriodic = formData.getString("sourceNamePeriodic");
@@ -114,14 +112,6 @@ public final class PluginDescriptorImpl extends BuildStepDescriptor<Publisher> {
 
   public void setUrl(String url) {
     this.collectorUrl = url;
-  }
-
-  public boolean isTimestampingEnabled() {
-    return timestampingEnabled;
-  }
-
-  public void setTimestampingEnabled(boolean value) {
-    timestampingEnabled = value;
   }
 
   public String getMaxLines() {

--- a/src/main/java/com/sumologic/jenkins/jenkinssumologicplugin/sender/LogListener.java
+++ b/src/main/java/com/sumologic/jenkins/jenkinssumologicplugin/sender/LogListener.java
@@ -24,12 +24,7 @@ public class LogListener extends ConsoleLogFilter {
     throws IOException, InterruptedException {
 
     PluginDescriptorImpl pluginDescriptor = PluginDescriptorImpl.getInstance();
-
     OutputStream stream = outputStream;
-
-    if (pluginDescriptor.isTimestampingEnabled()) {
-      stream = new TimestampingOutputStream(stream);
-    }
 
     if (pluginDescriptor.isBuildLogEnabled()) {
       abstractBuild.addAction(new SearchAction(abstractBuild));

--- a/src/main/java/com/sumologic/jenkins/jenkinssumologicplugin/sender/SumologicOutputStream.java
+++ b/src/main/java/com/sumologic/jenkins/jenkinssumologicplugin/sender/SumologicOutputStream.java
@@ -56,6 +56,11 @@ public class SumologicOutputStream extends LineTransformationOutputStream {
 
   @Override
   protected void eol(byte[] bytes, int i) throws IOException {
+    if (TimestampingOutputStream.shouldPutTimestamp(bytes, i)) {
+      byte[] timestamp = TimestampingOutputStream.getTimestampAsByteArray();
+      buffer.append(timestamp, 0, timestamp.length);
+    }
+
     buffer.append(bytes, 0, i);
     currentLines++;
 

--- a/src/main/java/com/sumologic/jenkins/jenkinssumologicplugin/sender/TimestampingOutputStream.java
+++ b/src/main/java/com/sumologic/jenkins/jenkinssumologicplugin/sender/TimestampingOutputStream.java
@@ -31,13 +31,14 @@ public class TimestampingOutputStream extends LineTransformationOutputStream {
     wrappedStream = stream;
   }
 
-  public static byte[] getTimestampAsByteArray() {
-    String timeStampStr = "[" + DATE_FORMAT.format(new Date()) + "] ";
-    byte[] timestampBytes = timeStampStr.getBytes();
-
-    return timestampBytes;
-  }
-
+  /**
+   * Heuristic used for determining multiline log messages, e.g. stack traces.
+   * For Sumo Logic purposes only lines prefixed with timestamp will be considered a beginning of new log message.
+   *
+   * @param bytes - byte array containing single log line
+   * @param i - log line length (can be less that bytes.length)
+   * @return false if line starts with whitespace, true otherwise
+   */
   public static boolean shouldPutTimestamp(byte[] bytes, int i) {
     String prefix = new String(bytes, 0, i < 4 ? i : 4, Charset.forName("UTF-8"));
 
@@ -46,6 +47,13 @@ public class TimestampingOutputStream extends LineTransformationOutputStream {
     }
 
     return true;
+  }
+
+  public static byte[] getTimestampAsByteArray() {
+    String timeStampStr = "[" + DATE_FORMAT.format(new Date()) + "] ";
+    byte[] timestampBytes = timeStampStr.getBytes();
+
+    return timestampBytes;
   }
 
   @Override

--- a/src/main/resources/com/sumologic/jenkins/jenkinssumologicplugin/SumoBuildNotifier/global.jelly
+++ b/src/main/resources/com/sumologic/jenkins/jenkinssumologicplugin/SumoBuildNotifier/global.jelly
@@ -65,10 +65,10 @@
 
 
     <f:entry
-        title="Enable automated output annotation with timestamps."
+        title="Enable automated console output annotation with timestamps."
         field="timestampingEnabled"
-        description="Check for automated timstamps at the beggining of every log line.">
-      <f:checkbox name="sumoplugin.timestampingEnabled" default="true"/>
+        description="Logs sent to Sumo Logic will either way be sent with timestamps.">
+      <f:checkbox name="sumoplugin.timestampingEnabled" default="false"/>
     </f:entry>
     <f:entry
         title="Enable automated build log sending to Sumo Logic."

--- a/src/main/resources/com/sumologic/jenkins/jenkinssumologicplugin/SumoBuildNotifier/global.jelly
+++ b/src/main/resources/com/sumologic/jenkins/jenkinssumologicplugin/SumoBuildNotifier/global.jelly
@@ -63,13 +63,6 @@
       <f:textbox name="sumoplugin.sourceCategoryBuildLogs" default="jenkinsBuildLogs"/>
     </f:entry>
 
-
-    <f:entry
-        title="Enable automated console output annotation with timestamps."
-        field="timestampingEnabled"
-        description="Logs sent to Sumo Logic will either way be sent with timestamps.">
-      <f:checkbox name="sumoplugin.timestampingEnabled" default="false"/>
-    </f:entry>
     <f:entry
         title="Enable automated build log sending to Sumo Logic."
         field="buildLogEnabled"


### PR DESCRIPTION
In order to simplify the plugin and possible interactions with other plugins, there's no longer an option to annotate console output with timestamps. 

However all logs are timestamped for internal Sumo Logic internal usage. 

Additionally a multiline log message heuristics was introduced. Whenever a new log line starts with a whitespace it will be treated as continuation of previous line. This is very useful for e.g. stack trace scenarios.