### PR TITLE
Added compression of log data sent to Sumo Logic

### DIFF
--- a/src/test/java/com/sumologic/jenkins/jenkinssumologicplugin/sender/SumoBuildNotifierTest.java
+++ b/src/test/java/com/sumologic/jenkins/jenkinssumologicplugin/sender/SumoBuildNotifierTest.java
@@ -90,7 +90,7 @@ public class SumoBuildNotifierTest {
 
     HttpEntityEnclosingRequest request = (HttpEntityEnclosingRequest) captor.getValue();
 
-    Assert.assertTrue("Wrong message length.", ModelFactory.createJenkinsModel(j.getInstance()).toJson().length() == request.getEntity().getContentLength());
+    Assert.assertTrue("Wrong message length.", ModelFactory.createJenkinsModel(j.getInstance()).toJson().length() >= request.getEntity().getContentLength());
 
 
 


### PR DESCRIPTION
Added gzip compression for all data sent to Sumo Logic from the plugin.

See https://help.sumologic.com/Send_Data/Sources/02Sources_for_Hosted_Collectors/HTTP_Source/Upload_Data_to_an_HTTP_Source for details.