### PR TITLE
Decode url as secret

### DIFF
--- a/src/main/java/com/sumologic/jenkins/jenkinssumologicplugin/PluginDescriptorImpl.java
+++ b/src/main/java/com/sumologic/jenkins/jenkinssumologicplugin/PluginDescriptorImpl.java
@@ -48,7 +48,7 @@ import static hudson.init.InitMilestone.JOB_LOADED;
 @Extension
 public final class PluginDescriptorImpl extends BuildStepDescriptor<Publisher> {
 
-    private String url;
+    private Secret url;
     private transient SumoMetricDataPublisher sumoMetricDataPublisher;
     private static LogSenderHelper logSenderHelper = null;
     private String queryPortal;
@@ -247,11 +247,11 @@ public final class PluginDescriptorImpl extends BuildStepDescriptor<Publisher> {
         this.metricDataPrefix = metricDataPrefix;
     }
 
-    public String getUrl() {
+    public Secret getUrl() {
         return url;
     }
 
-    public void setUrl(String url) {
+    public void setUrl(Secret url) {
         this.url = url;
     }
 

--- a/src/main/java/com/sumologic/jenkins/jenkinssumologicplugin/PluginDescriptorImpl.java
+++ b/src/main/java/com/sumologic/jenkins/jenkinssumologicplugin/PluginDescriptorImpl.java
@@ -247,8 +247,8 @@ public final class PluginDescriptorImpl extends BuildStepDescriptor<Publisher> {
         this.metricDataPrefix = metricDataPrefix;
     }
 
-    public Secret getUrl() {
-        return url;
+    public String getUrl() {
+        return url.getPlainText();
     }
 
     public void setUrl(Secret url) {


### PR DESCRIPTION
We are seeing exceptions along the lines of:

```WARNING	c.s.j.j.sender.LogSender#sendLogs: Could not send log to Sumo Logic: java.lang.IllegalArgumentException: Invalid uri '{AQAAABAAAADA+JNeDFM2FHISqomuqExio9nSNv05k+bYqiua8RnXmcAHLqVPRglB2OaK+cfsAdRr9p/FTJyPvY5oVeSOMIkAHQ2ZCphE9x2Bb1RpDZDy1TBwUxuGdghES6pqvAHXARXIEYeOMZQZTifQALEwbrTQwoF2Bh0pqdc4d4vSUQJkbxLkNk1HZ7b4nceToDWFGrDvEFsSPwcIRdv9CdEU++hjPxm85J8VFTH4Cyd4QiZfj6rNTm7TD6aKselX5WF1yKib9WaCwIUk+5iByY/7kOfoEw==}': incorrect path```

I suspect this may be caused by the url being stored as a secret, but not decoded when the config is reloaded from disk.